### PR TITLE
Added Support class method inside Proposition Node

### DIFF
--- a/src/sneps/network/PropositionNode.java
+++ b/src/sneps/network/PropositionNode.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import sneps.exceptions.CustomException;
 import sneps.exceptions.NodeNotFoundInNetworkException;
+import sneps.exceptions.NodeNotFoundInPropSetException;
 import sneps.exceptions.NotAPropositionNodeException;
 import sneps.network.classes.setClasses.ChannelSet;
 import sneps.network.classes.setClasses.NodeSet;
@@ -217,6 +218,16 @@ public class PropositionNode extends Node {
 	}
 	public Hashtable<String, PropositionSet> getAssumptionBasedSupport() {
 		return basicSupport.getAssumptionBasedSupport();
+		
+	}
+	public Hashtable<String, PropositionSet> getJustificationSupport() {
+		return basicSupport.getJustificationSupport();
+	}
+	public void addJustificationBasedSupport(PropositionSet propSet) throws NodeNotFoundInPropSetException, NotAPropositionNodeException, NodeNotFoundInNetworkException{
+		basicSupport.addJustificationBasedSupport(propSet);
+	}
+	public boolean removeNodeFromSupports(PropositionNode propNode) {
+		return basicSupport.removeNodeFromSupports(propNode);
 		
 	}
 

--- a/src/sneps/snebr/Context.java
+++ b/src/sneps/snebr/Context.java
@@ -164,6 +164,23 @@ public class Context {
 
         return asserted;
     }
+    
+    /**
+     * When Removing a node from context, Therefore we must remove it from this Context's nodes Supports also
+     * @param PropositionNode, The node to be removed from all Context's Supports
+     * @throws NodeNotFoundInNetworkException 
+     * @throws NotAPropositionNodeException 
+     */
+    public void removeNodeFromContext(PropositionNode propNode) throws NotAPropositionNodeException, NodeNotFoundInNetworkException{
+    	
+    	//Remove this node from Context!! Omar Part
+    	//.........................................
+    	
+    	//Remove this node from All Context's nodes Supports!! Amr Part
+    	int[] contextSet = PropositionSet.getPropsSafely(hyps /*TODO change hyps to be the new set without the propNode*/); //The set of hyps after Omar removes from it the propNode!!
+    	for(int i = 0; i< contextSet.length; i++)
+    		((PropositionNode)Network.getNodeById(contextSet[i])).removeNodeFromSupports(propNode);
+    }
 
     /**
      * Adds a name to the set of names of the context if not a duplicate.

--- a/src/sneps/snebr/Controller.java
+++ b/src/sneps/snebr/Controller.java
@@ -1,6 +1,7 @@
 package sneps.snebr;
 
 import sneps.exceptions.*;
+import sneps.network.PropositionNode;
 import sneps.network.classes.setClasses.PropositionSet;
 
 import java.util.HashSet;

--- a/src/sneps/snebr/Support.java
+++ b/src/sneps/snebr/Support.java
@@ -1,9 +1,9 @@
 package sneps.snebr;
 
-
-
+import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.Stack;
 
 import sneps.exceptions.NodeNotFoundInNetworkException;
 import sneps.exceptions.NodeNotFoundInPropSetException;
@@ -14,14 +14,24 @@ import sneps.network.classes.Semantic;
 import sneps.network.classes.setClasses.PropositionSet;
 
 public class Support {
+	private int id;
 	private Hashtable<String, PropositionSet> justificationSupport;
 	private Hashtable<String, PropositionSet> assumptionBasedSupport;
+	private ArrayList<ArrayList<Integer>> mySupportsTree;
 	private boolean hasChildren;
+	private boolean TreeComputed;
 
 	public Support(int id) throws NotAPropositionNodeException, NodeNotFoundInNetworkException {
+		this.id = id;
 		assumptionBasedSupport = new Hashtable<String, PropositionSet>();
 		justificationSupport = new Hashtable<String, PropositionSet>();
-		assumptionBasedSupport.put(Integer.toString(id), new PropositionSet(id));
+		mySupportsTree = new ArrayList<ArrayList<Integer>>();
+		PropositionSet intialSet = new PropositionSet(id);
+		assumptionBasedSupport.put(Integer.toString(id), intialSet);
+		ArrayList<Integer> intialTree = new ArrayList<Integer>();
+		intialTree.add(id);
+		mySupportsTree.add(intialTree);
+		TreeComputed = true;
 	}
 
 	@Override
@@ -34,49 +44,65 @@ public class Support {
 		return justificationSupport;
 	}
 
-	public boolean HasChildren() {
+	private boolean HasChildren() {
 		return hasChildren;
 	}
 
-	// clean
+	private void setHasChildren(boolean flag) {
+		hasChildren = flag;
+	}
 
-	// union kol el combinations bta3et el justifications bta3et el assumptions
+	private boolean isTreeComputed() {
+		return TreeComputed;
+	}
+
+	private void setTreeComputed(boolean flag) {
+		TreeComputed = flag;
+	}
 
 	public void addJustificationBasedSupport(PropositionSet propSet)
 			throws NodeNotFoundInPropSetException, NotAPropositionNodeException, NodeNotFoundInNetworkException {
-		if (!hasChildren) {
+		if (!HasChildren()) {
 			assumptionBasedSupport = new Hashtable<String, PropositionSet>();
 		}
 		String hash = propSet.getHash();
 		if (!justificationSupport.containsKey(hash)) {
 			justificationSupport.put(hash, propSet);
-			hasChildren = true;
+			setHasChildren(true);
+			setTreeComputed(false);
 			int[] nodes = PropositionSet.getPropsSafely(propSet);
 			PropositionSet setSofar = new PropositionSet();
-
+			int idx = 1;
 			PropositionNode node = (PropositionNode) Network.getNodeById(nodes[0]);
+			if(node.getId() == this.getId()){
+				node = (PropositionNode) Network.getNodeById(nodes[1]);
+				idx++;
+			}
 			Hashtable<String, PropositionSet> NodeAssumptions = node.getAssumptionBasedSupport();
 			Iterator<PropositionSet> it = NodeAssumptions.values().iterator();
 
 			while (it.hasNext()) {
 				setSofar = it.next();
-				RecCall(nodes, setSofar, 1);
+				computeAssumptionRec(nodes, setSofar, idx);
 			}
 		}
 	}
 
-	private void RecCall(int[] nodes, PropositionSet setSofar, int idx)
+	private void computeAssumptionRec(int[] nodes, PropositionSet setSofar, int idx)
 			throws NodeNotFoundInNetworkException, NotAPropositionNodeException {
 		if (idx == nodes.length) {
 			assumptionBasedSupport.put(setSofar.getHash(), setSofar);
 			return;
 		}
 		PropositionNode node = (PropositionNode) Network.getNodeById(nodes[idx]);
+		if(node.getId() == this.getId()){
+			return;
+		}
 		Hashtable<String, PropositionSet> NodeAssumptions = node.getAssumptionBasedSupport();
 		Iterator<PropositionSet> it = NodeAssumptions.values().iterator();
 		idx += 1;
 		while (it.hasNext()) {
-			RecCall(nodes, setSofar.union(it.next()), idx);
+			computeAssumptionRec(nodes, setSofar.union(it.next()), idx);
 		}
 
 	}
@@ -84,17 +110,88 @@ public class Support {
 	public void lazyEvaluationTree() {
 
 	}
+	
+	public ArrayList<ArrayList<Integer>> getMySupportsTree() throws NotAPropositionNodeException, NodeNotFoundInNetworkException{
+		if(isTreeComputed())
+			return mySupportsTree;
+		
+		mySupportsTree = new ArrayList<ArrayList<Integer>>();
+		Iterator<PropositionSet> it = justificationSupport.values().iterator();
+		ArrayList<Integer> setSoFar = new ArrayList<Integer>();
+		setSoFar.add(getId());
+		while(it.hasNext()){
+			PropositionSet propSet = it.next();
+			int[] nodes = PropositionSet.getPropsSafely(propSet);
+			for(int i = 0; i < nodes.length ; i++){
+				 computeTreeRec(setSoFar, (PropositionNode) Network.getNodeById(nodes[i]));
+				 setSoFar = new ArrayList<Integer>();
+				 setSoFar.add(getId());
+			}
+		}
+		
+		mySupportsTree = reverse(mySupportsTree);
+		setTreeComputed(true);
+		return mySupportsTree;
+	}
+	
+	private ArrayList<ArrayList<Integer>> reverse(ArrayList<ArrayList<Integer>> mySupportsTree) {
+		Stack<Integer> tmp = new Stack<Integer>();
+		ArrayList<ArrayList<Integer>> returnedList = new ArrayList<ArrayList<Integer>>();
+		ArrayList<Integer> smallList = new ArrayList<Integer>();
+		for(int i = 0; i < mySupportsTree.size(); i++){
+			ArrayList<Integer> inst = mySupportsTree.get(i);
+			for (int j = 0; j < inst.size(); j++) {
+				tmp.push(inst.get(j));
+			}
+			for (int j = 0; j < inst.size(); j++) {
+				smallList.add(tmp.pop());
+			}
+			returnedList.add(smallList);
+			smallList = new ArrayList<Integer>();
+		}
+		return returnedList;
+	}
+
+	private ArrayList<Integer> computeTreeRec(ArrayList<Integer> setSoFar, PropositionNode node) throws NotAPropositionNodeException, NodeNotFoundInNetworkException {
+			if(!node.getBasicSupport().HasChildren()){
+				ArrayList<Integer> temp = new ArrayList<Integer>();
+				temp.addAll(setSoFar);
+				setSoFar.add(node.getId());	
+				mySupportsTree.add(setSoFar);
+				return temp;
+			}
+			if(setSoFar.contains(node.getId())){
+				return setSoFar;
+			}
+			ArrayList<Integer> temp = new ArrayList<Integer>();
+			temp.addAll(setSoFar);
+			setSoFar.add(node.getId());	
+			Iterator<PropositionSet> it = node.getJustificationSupport().values().iterator();
+			while(it.hasNext()){
+				PropositionSet propSet = it.next();
+				int[] nodes = PropositionSet.getPropsSafely(propSet);
+				for(int i = 0; i < nodes.length ; i++){
+					setSoFar = computeTreeRec(setSoFar, (PropositionNode) Network.getNodeById(nodes[i]));
+					
+				}
+			}
+			
+			return temp;
+	}
 
 	public Hashtable<String, PropositionSet> getAssumptionBasedSupport() {
 		return assumptionBasedSupport;
 	}
-	
+
 	public boolean removeNodeFromSupports(PropositionNode propNode) {
 		// TODO Auto-generated method stub
 		return false;
 	}
 
-	// toString for UI SNePSlog
+	public int getId() {
+		return id;
+	}
+
 	public static void main(String[] args)
 			throws NotAPropositionNodeException, NodeNotFoundInPropSetException, NodeNotFoundInNetworkException {
 		Semantic sem = new Semantic("PropositionNode");
@@ -145,18 +242,21 @@ public class Support {
 		PropositionNode n20 = (PropositionNode) net.getNode("o");
 		PropositionNode n21 = (PropositionNode) net.getNode("t");
 
-		int[] pqr = new int[3];
+		int[] pqr = new int[4];
 		pqr[0] = 1;
 		pqr[1] = 2;
 		pqr[2] = 3;
+		pqr[3] = 0;
+		
 
 		int[] mn = new int[2];
 		mn[0] = 5;
 		mn[1] = 4;
 
-		int[] vz = new int[2];
+		int[] vz = new int[3];
 		vz[0] = 6;
 		vz[1] = 7;
+		vz[2] = 0;
 
 		int[] ab = new int[2];
 		ab[0] = 9;
@@ -178,9 +278,10 @@ public class Support {
 		ij[0] = 16;
 		ij[1] = 17;
 
-		int[] kl = new int[2];
+		int[] kl = new int[3];
 		kl[0] = 18;
 		kl[1] = 19;
+		kl[2] = 5;
 
 		int[] ot = new int[2];
 		ot[0] = 20;
@@ -207,10 +308,15 @@ public class Support {
 		n3.addJustificationBasedSupport(s6);
 		n0.addJustificationBasedSupport(s1);
 		n0.addJustificationBasedSupport(s10);
-
-		System.out.println(n0.getBasicSupport().toString());
+		
+		//Hashtable<String, PropositionSet> justificationSupport = n0.getAssumptionBasedSupport();
+		ArrayList<ArrayList<Integer>> tree = n0.getBasicSupport().getMySupportsTree();
+		
+		
+			System.out.println(tree.toString());
+		
+		
 
 	}
 
-	
 }

--- a/src/sneps/snebr/Support.java
+++ b/src/sneps/snebr/Support.java
@@ -1,26 +1,14 @@
 package sneps.snebr;
 
-import java.util.Collection;
+
+
 import java.util.Hashtable;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
-import java.util.Map.Entry;
 
-import javafx.beans.InvalidationListener;
-import javafx.beans.property.MapProperty;
-import javafx.beans.property.ReadOnlyBooleanProperty;
-import javafx.beans.property.ReadOnlyIntegerProperty;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
-import javafx.collections.MapChangeListener;
-import javafx.collections.ObservableMap;
-import sneps.exceptions.CustomException;
 import sneps.exceptions.NodeNotFoundInNetworkException;
 import sneps.exceptions.NodeNotFoundInPropSetException;
 import sneps.exceptions.NotAPropositionNodeException;
 import sneps.network.Network;
-import sneps.network.Node;
 import sneps.network.PropositionNode;
 import sneps.network.classes.Semantic;
 import sneps.network.classes.setClasses.PropositionSet;
@@ -99,6 +87,11 @@ public class Support {
 
 	public Hashtable<String, PropositionSet> getAssumptionBasedSupport() {
 		return assumptionBasedSupport;
+	}
+	
+	public boolean removeNodeFromSupports(PropositionNode propNode) {
+		// TODO Auto-generated method stub
+		return false;
 	}
 
 	// toString for UI SNePSlog
@@ -204,18 +197,20 @@ public class Support {
 		PropositionSet s9 = new PropositionSet(kl);
 		PropositionSet s10 = new PropositionSet(ot);
 
-		n4.getBasicSupport().addJustificationBasedSupport(s7);
-		n4.getBasicSupport().addJustificationBasedSupport(s8);
-		n5.getBasicSupport().addJustificationBasedSupport(s9);
-		n1.getBasicSupport().addJustificationBasedSupport(s2);
-		n1.getBasicSupport().addJustificationBasedSupport(s3);
-		n2.getBasicSupport().addJustificationBasedSupport(s4);
-		n3.getBasicSupport().addJustificationBasedSupport(s5);
-		n3.getBasicSupport().addJustificationBasedSupport(s6);
-		n0.getBasicSupport().addJustificationBasedSupport(s1);
-		n0.getBasicSupport().addJustificationBasedSupport(s10);
+		n4.addJustificationBasedSupport(s7);
+		n4.addJustificationBasedSupport(s8);
+		n5.addJustificationBasedSupport(s9);
+		n1.addJustificationBasedSupport(s2);
+		n1.addJustificationBasedSupport(s3);
+		n2.addJustificationBasedSupport(s4);
+		n3.addJustificationBasedSupport(s5);
+		n3.addJustificationBasedSupport(s6);
+		n0.addJustificationBasedSupport(s1);
+		n0.addJustificationBasedSupport(s10);
 
 		System.out.println(n0.getBasicSupport().toString());
 
 	}
+
+	
 }


### PR DESCRIPTION
In order to make it easier for anyone in calling supports. 
If we want to add JustificationBasedSupport:
Instead of ... PropositionNode.getBasicSupport().addJustificationBasedSupport(PropositionSet propSet);
Will be ..... PropositionNode.addJustificationBasedSupport(PropositionSet propSet) 