### PR TITLE
BUG FIXES and some refactoring

### DIFF
--- a/src/sneps/network/Network.java
+++ b/src/sneps/network/Network.java
@@ -575,6 +575,7 @@ public class Network implements Serializable {
 			if(semantic.getSemanticType().equals("PropositionNode")){
 				PropositionNode propNode =  new PropositionNode(b);
 				nodes.put(identifier, propNode);
+				propositionNodes.put(identifier, propNode);
 				try {
 					nodesIndex.add(propNode.getId(), propNode);
 					propNode.setBasicSupport();

--- a/src/sneps/network/Network.java
+++ b/src/sneps/network/Network.java
@@ -2118,6 +2118,7 @@ public class Network implements Serializable {
 		molCounter = 0;
 		patternCounter = 0;
 		varCounter = 0;
+		Node.setCount(0);
 		userDefinedMolSuffix.clear();
 		userDefinedPatSuffix.clear();
 		userDefinedVarSuffix.clear();

--- a/src/sneps/network/classes/setClasses/PropositionSet.java
+++ b/src/sneps/network/classes/setClasses/PropositionSet.java
@@ -154,7 +154,7 @@ public class PropositionSet {
 
 		while (i < props.length || j < props1.length) {
 
-			if (i >= props.length) {
+			if (i >= props.length) {  // length of arg passed
 				props2[k++] = props1[j++];
 				continue;
 			} else if (j >= props1.length) {
@@ -165,7 +165,7 @@ public class PropositionSet {
 			if(props[i] == props1[j]) {
 				props2[k] = props[i];
 				i++;j++;
-			} else if (props[i] < props1[i]) {
+			} else if (props[i] < props1[j]) {
 				props2[k] = props[i];
 				i++;
 			} else {

--- a/src/sneps/snebr/Context.java
+++ b/src/sneps/snebr/Context.java
@@ -105,25 +105,20 @@ public class Context {
 
     /**
      * Checks if a propositions is asserted in this context
+     *
      * @param p the proposition to be checked for assertion.
      * @return <code>true</code> if the proposition exists, otherwise <code>false</code>
-     * @throws NotAPropositionNodeException If the node p is not a proposition.
+     * @throws NotAPropositionNodeException   If the node p is not a proposition.
      * @throws NodeNotFoundInNetworkException If the node p doesn't exist in the network.
      */
     public boolean isAsserted(PropositionNode p) throws NotAPropositionNodeException, NodeNotFoundInNetworkException {
         int hyp = p.getId();
 
-        if (Arrays.binarySearch(PropositionSet.getPropsSafely(this.hyps), hyp) < 0) {
-            return true;
-        } else if (isSupported(p)) {
-            return true;
-        } else {
-            return false;
-        }
-
+        return Arrays.binarySearch(PropositionSet.getPropsSafely(this.hyps), hyp) > 0
+                || isSupported(p);
     }
 
-    private boolean isSupported(PropositionNode node) {
+    public boolean isSupported(PropositionNode node) {
         Collection<PropositionSet> assumptionSet = node.getBasicSupport()
                 .getAssumptionBasedSupport()
                 .values();
@@ -148,10 +143,10 @@ public class Context {
         }
         for (PropositionNode node : allPropositionNodes) {
             try {
-                if (Arrays.binarySearch(hyps, node.getId()) < 0) {
-                    asserted.add(node.getId());
+                if (Arrays.binarySearch(hyps, node.getId()) > 0) {
+                    asserted = asserted.add(node.getId());
                 } else if (isSupported(node)) {
-                    asserted.add(node.getId());
+                    asserted = asserted.add(node.getId());
                 }
             } catch (NodeNotFoundInNetworkException e1) {
                 return null;

--- a/src/sneps/snebr/ContextSet.java
+++ b/src/sneps/snebr/ContextSet.java
@@ -1,7 +1,9 @@
 package sneps.snebr;
 
 
+import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.Set;
 
 public class ContextSet {
 
@@ -22,6 +24,14 @@ public class ContextSet {
     public ContextSet(String name) {
         this();
         this.contexts.put(name, new Context(name));
+    }
+
+    public void clear() {
+        contexts.clear();
+    }
+
+    public Set<String> getNames() {
+        return contexts.keySet();
     }
 
     /**

--- a/src/sneps/snebr/Controller.java
+++ b/src/sneps/snebr/Controller.java
@@ -37,7 +37,7 @@ public class Controller {
     /**
      * Clears the knowledge base
      */
-    public static void clearKB() {
+    public static void clearSNeBR() {
         contextSet.clear();
         currContext = "default";
         contextSet.add(new Context(currContext));

--- a/src/sneps/snebr/Controller.java
+++ b/src/sneps/snebr/Controller.java
@@ -4,6 +4,7 @@ import sneps.exceptions.*;
 import sneps.network.classes.setClasses.PropositionSet;
 
 import java.util.HashSet;
+import java.util.Set;
 
 public class Controller {
     private static String currContext = "default";
@@ -30,6 +31,16 @@ public class Controller {
      */
     public static Context createContext() {
         return new Context();
+    }
+
+
+    /**
+     * Clears the knowledge base
+     */
+    public static void clearKB() {
+        contextSet.clear();
+        currContext = "default";
+        contextSet.add(new Context(currContext));
     }
 
     /**
@@ -179,6 +190,10 @@ public class Controller {
 
     public static void checkForContradiction(Context c){
         // TODO: 13/03/18
+    }
+
+    public static Set<String> getAllNamesOfContexts() {
+        return contextSet.getNames();
     }
 
     /**

--- a/tests/ContextSetTest.java
+++ b/tests/ContextSetTest.java
@@ -1,8 +1,6 @@
 package tests;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import sneps.exceptions.CustomException;
 import sneps.exceptions.DuplicateContextNameException;
 import sneps.exceptions.NodeNotFoundInNetworkException;
@@ -20,14 +18,29 @@ public class ContextSetTest {
     private Context context;
     private ContextSet contextSet;
     final static String contextName = "test context";
-    private final Semantic semantic = new Semantic("PropositionNode");
+    private static final Semantic semantic = new Semantic("PropositionNode");
 
-    @Before
-    public void setUp() throws DuplicateContextNameException, NotAPropositionNodeException, CustomException, NodeNotFoundInNetworkException {
+    @BeforeClass
+    public static void setUp() throws NotAPropositionNodeException, NodeNotFoundInNetworkException {
         for (int i = 0; i < 8889; i++)
             Network.buildBaseNode("n"+i, semantic);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Network.clearNetwork();
+        Controller.clearSNeBR();
+    }
+
+    @Before
+    public void beforeEach() throws NotAPropositionNodeException, NodeNotFoundInNetworkException, DuplicateContextNameException {
         context = Controller.createContext(contextName, new PropositionSet(new int [] {1,3,4}));
         contextSet = new ContextSet(context);
+    }
+
+    @After
+    public void removeContext() {
+        Controller.removeContext(contextName);
     }
 
     @Test
@@ -52,11 +65,6 @@ public class ContextSetTest {
     public void identicalContext() throws DuplicateContextNameException, NotAPropositionNodeException, CustomException, NodeNotFoundInNetworkException {
         Context c2 = Controller.createContext("context 2", new PropositionSet(new int [] {1,3,4}));
         assertEquals(contextSet.identicalContext(c2), context);
-    }
-
-    @After
-    public void removeContext() {
-        Controller.removeContext(contextName);
     }
 
 }

--- a/tests/ControllerTest.java
+++ b/tests/ControllerTest.java
@@ -1,6 +1,8 @@
 package tests;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -12,6 +14,7 @@ import sneps.network.classes.Semantic;
 import sneps.network.classes.setClasses.PropositionSet;
 import sneps.snebr.Context;
 import sneps.snebr.Controller;
+import sneps.snebr.Support;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -32,7 +35,7 @@ public class ControllerTest {
 
     @After
     public void tearDown(){
-        Controller.removeContext(testContextName);
+        Controller.clearKB();
     }
 
     @Test
@@ -140,7 +143,33 @@ public class ControllerTest {
     }
 
     @Test
-    public void setCurrentContext() {
+    public void setCurrentContext() throws DuplicateContextNameException, NotAPropositionNodeException, NodeNotFoundInNetworkException {
+        Controller.createContext("c6", new PropositionSet(new int [] {5,7}));
+        Controller.createContext("c5", new PropositionSet(new int [] {5,7}));
+
+        Controller.setCurrentContext("c5");
+        assertEquals(Controller.getCurrentContext(), Controller.getContextByName("c5"));
+
+    }
+
+    @Test
+    public void isAsserted() throws NotAPropositionNodeException, NodeNotFoundInNetworkException, NodeNotFoundInPropSetException, ContextNameDoesntExistException, CustomException {
+        PropositionSet p = new PropositionSet(new int [] {12, 58});
+        Controller.addPropsToCurrentContext(p);
+        ((PropositionNode)Network.getNodeById(10)).getBasicSupport().addJustificationBasedSupport(p);
+        assertTrue(Controller.getCurrentContext().isAsserted((PropositionNode)Network.getNodeById(12)));
+        assertTrue(Controller.getCurrentContext().isAsserted((PropositionNode)Network.getNodeById(58)));
+
+    }
+
+    @Test
+    public void allAsserted() throws NotAPropositionNodeException, NodeNotFoundInNetworkException, ContextNameDoesntExistException, CustomException, NodeNotFoundInPropSetException {
+        PropositionSet p = new PropositionSet(new int [] {12, 58, 10});
+        PropositionSet supp = new PropositionSet(new int [] {12,58});
+        PropositionSet p1 = new PropositionSet(new int [] {12, 58, 32});
+        Controller.addPropsToCurrentContext(p1);
+        ((PropositionNode)Network.getNodeById(10)).getBasicSupport().addJustificationBasedSupport(supp);
+        assertTrue(p.isSubSet(Controller.getCurrentContext().allAsserted()));
     }
 
     @Test
@@ -154,4 +183,14 @@ public class ControllerTest {
     @Test
     public void getContextByName() {
     }
+
+    @Test
+    public void getNames() throws NotAPropositionNodeException, NodeNotFoundInNetworkException, DuplicateContextNameException {
+        PropositionSet set = new PropositionSet(new int[] {5,6,7,8});
+        for (int i = 1; i < 4; i++)
+            Controller.createContext("c"+i, set);
+        for (int i = 1; i < 4; i++)
+            assertTrue(Controller.getAllNamesOfContexts().contains("c" + i));
+    }
+
 }

--- a/tests/ControllerTest.java
+++ b/tests/ControllerTest.java
@@ -1,10 +1,7 @@
 package tests;
 
-import org.hamcrest.CoreMatchers;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
+
 import static org.junit.Assert.*;
 
 import sneps.exceptions.*;
@@ -14,10 +11,6 @@ import sneps.network.classes.Semantic;
 import sneps.network.classes.setClasses.PropositionSet;
 import sneps.snebr.Context;
 import sneps.snebr.Controller;
-import sneps.snebr.Support;
-
-import java.util.Arrays;
-import java.util.HashSet;
 
 public class ControllerTest {
 
@@ -25,17 +18,26 @@ public class ControllerTest {
     private static final String testContext2 = "Test context2";
     private static final Semantic semantic = new Semantic("PropositionNode");
 
-    @Before
-    public void setUp() throws DuplicateContextNameException, NotAPropositionNodeException, NodeNotFoundInNetworkException {
-        Controller.createContext(testContextName);
+    @BeforeClass
+    public static void setUp() throws NotAPropositionNodeException, NodeNotFoundInNetworkException {
         for (int i = 0; i < 8889; i++)
             Network.buildBaseNode("n"+i, semantic);
     }
 
+    @Before
+    public void beforeEach() throws DuplicateContextNameException {
+        Controller.createContext(testContextName);
+    }
 
     @After
-    public void tearDown(){
-        Controller.clearKB();
+    public void afterEach() {
+        Controller.clearSNeBR();
+    }
+
+
+    @AfterClass
+    public static void tearDown(){
+        Network.clearNetwork();
     }
 
     @Test
@@ -159,16 +161,26 @@ public class ControllerTest {
         ((PropositionNode)Network.getNodeById(10)).getBasicSupport().addJustificationBasedSupport(p);
         assertTrue(Controller.getCurrentContext().isAsserted((PropositionNode)Network.getNodeById(12)));
         assertTrue(Controller.getCurrentContext().isAsserted((PropositionNode)Network.getNodeById(58)));
+        assertTrue(Controller.getCurrentContext().isAsserted((PropositionNode)Network.getNodeById(10)));
+        assertFalse(Controller.getCurrentContext().isAsserted((PropositionNode) Network.getNodeById(37)));
+    }
 
+    @Test
+    public void isSupport() throws NotAPropositionNodeException, NodeNotFoundInNetworkException, ContextNameDoesntExistException, CustomException, NodeNotFoundInPropSetException {
+        ((PropositionNode)Network.getNodeById(10)).getBasicSupport().addJustificationBasedSupport(new PropositionSet(new int [] {4,5,7}));
+        PropositionSet p = new PropositionSet(new int [] {4,5,7});
+        Controller.addPropsToCurrentContext(p);
+        assertTrue(Controller.getCurrentContext().isSupported((PropositionNode) Network.getNodeById(10)));
+        assertFalse(Controller.getCurrentContext().isAsserted((PropositionNode) Network.getNodeById(37)));
     }
 
     @Test
     public void allAsserted() throws NotAPropositionNodeException, NodeNotFoundInNetworkException, ContextNameDoesntExistException, CustomException, NodeNotFoundInPropSetException {
         PropositionSet p = new PropositionSet(new int [] {12, 58, 10});
-        PropositionSet supp = new PropositionSet(new int [] {12,58});
+        PropositionSet support = new PropositionSet(new int [] {12,58});
         PropositionSet p1 = new PropositionSet(new int [] {12, 58, 32});
         Controller.addPropsToCurrentContext(p1);
-        ((PropositionNode)Network.getNodeById(10)).getBasicSupport().addJustificationBasedSupport(supp);
+        ((PropositionNode)Network.getNodeById(10)).getBasicSupport().addJustificationBasedSupport(support);
         assertTrue(p.isSubSet(Controller.getCurrentContext().allAsserted()));
     }
 

--- a/tests/NetworkTest.java
+++ b/tests/NetworkTest.java
@@ -27,11 +27,15 @@ public class NetworkTest {
 
     @Test
     public void buildBaseNode() throws NotAPropositionNodeException, NodeNotFoundInNetworkException {
+        int sizeOfNodes = Network.getNodes().size();
+        int sizeOfProps = Network.getPropositionNodes().size();
         Network.buildBaseNode("n0", semantic);
         Node n0 =  Network.getNode("n0");
         assertTrue(Network.getNodeById(0) instanceof PropositionNode);
         assertEquals(n0, Network.getNodeById(0));
         assertTrue(n0.getTerm() instanceof Base);
+        assertEquals(Network.getNodes().size(), sizeOfNodes + 1);
+        assertEquals(Network.getPropositionNodes().size(), sizeOfProps + 1);
     }
 
     @After

--- a/tests/NetworkTest.java
+++ b/tests/NetworkTest.java
@@ -1,8 +1,6 @@
 package tests;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 
 import sneps.exceptions.CustomException;
 import sneps.exceptions.NodeCannotBeRemovedException;
@@ -13,16 +11,24 @@ import sneps.network.Node;
 import sneps.network.PropositionNode;
 import sneps.network.classes.Semantic;
 import sneps.network.classes.term.Base;
+import sneps.snebr.Controller;
+
 import static org.junit.Assert.*;
 
 public class NetworkTest {
-     Semantic semantic;
+     static Semantic semantic;
     final static String semanticType = "PropositionNode";
     
 
-    @Before
-    public void setUp() {
+    @BeforeClass
+    public static void setUp() {
     	semantic = new Semantic(semanticType);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Network.clearNetwork();
+        Controller.clearSNeBR();
     }
 
     @Test

--- a/tests/PropositionSetTest.java
+++ b/tests/PropositionSetTest.java
@@ -2,22 +2,31 @@ package tests;
 
 import static org.junit.Assert.*;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import sneps.exceptions.*;
 import sneps.network.Network;
 import sneps.network.classes.Semantic;
 import sneps.network.classes.setClasses.PropositionSet;
+import sneps.snebr.Controller;
 
 
 public class PropositionSetTest {
 
-    private final Semantic semantic = new Semantic("PropositionNode");
+    private static final Semantic semantic = new Semantic("PropositionNode");
 
-    @Before
-    public void setUp() throws NotAPropositionNodeException, NodeNotFoundInNetworkException {
+    @BeforeClass
+    public static void setUp() throws NotAPropositionNodeException, NodeNotFoundInNetworkException {
         for (int i = 0; i < 8889; i++)
             Network.buildBaseNode("n"+i, semantic);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Network.clearNetwork();
+        Controller.clearSNeBR();
     }
 
     @Test
@@ -68,6 +77,7 @@ public class PropositionSetTest {
         PropositionSet superSet = new PropositionSet(props1);
         PropositionSet subSet = new PropositionSet(props2);
         assertTrue(subSet.isSubSet(superSet));
+        assertFalse(superSet.isSubSet(subSet));
 
     }
 


### PR DESCRIPTION
- `propositionNodes` is now filled with newly built `base` nodes, it was always empty.

- Bug fix in `PropositionSet`'s `union` method

- Clearing the network and `SNeBR` after the tests.

- Some refactoring including renaming `clearKB`  to `clearSNeBR`.